### PR TITLE
Docs for creating route table for Pod network

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,8 +2,9 @@
 
 ## Prerequisites
 
-* A K8s cluster with version 1.10, 1.12, or 1.14 using VPC network
+* A K8s cluster with version 1.10, 1.12, or 1.14 in a VPC network
 * Each node should have a node name same as its IP address, or CCM can't initialize them. Using `--hostname-override` flag of `kubelet` is recommended.
+* A route table is required for the Pod network. We build `route-ctl` to support the route table creation. See [route-ctl](https://github.com/TencentCloud/tencentcloud-cloud-controller-manager/tree/master/route-ctl).
 
 ## Tencent Cloud CCM Installation
 
@@ -15,7 +16,7 @@ Clear the flag `--cloud-provider` of `kube-apiserver` and `kube-controller-manag
 
 The sample manifests are [here](https://raw.githubusercontent.com/TencentCloud/tencentcloud-cloud-controller-manager/master/docs/example-manifests/out-of-tree/kube-apiserver.yaml).
 
-More details are in [the official documents](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager)
+More details are in [the official documents](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager).
 
 ### Update the kubelet configuration
 
@@ -30,7 +31,7 @@ The following parameters should be determined before deploying. These placeholde
 | ---- | ---- | ---- |
 | <REGION> | The region your CVMs assisted | All region IDs(with a prefix `ap-`) could be found in section `Region List` of the [document](https://intl.cloud.tencent.com/document/api/213/31574) |
 | <SECRET_ID> & <SECRET_KEY> | Identity to access the Tencent Cloud API | Following the [document](https://intl.cloud.tencent.com/document/product/598/34228) |
-| <CLUSTER_NETWORK_ROUTE_TABLE_NAME> | ID of the route table of Pod network | It can be found on [TencentCloud Route Console](https://console.cloud.tencent.com/vpc/route) , usually has a prefix `rtb-`. |
+| <CLUSTER_NETWORK_ROUTE_TABLE_NAME> | Route table name of the Pod network | The route table must be created via the utility `route-ctl`. See [route-ctl](https://github.com/TencentCloud/tencentcloud-cloud-controller-manager/tree/master/route-ctl) |
 | <TENCENTCLOUD_CLOUD_CONTROLLER_MANAGER_VPC_ID> | ID of the current VPC Network | It can be found on [TencentCloud VPC Console](https://console.cloud.tencent.com/vpc/vpc) , usually has a prefix `vpc-`. |
 
 
@@ -47,7 +48,13 @@ To deploy CCM,
 kubectl apply -f https://raw.githubusercontent.com/TencentCloud/tencentcloud-cloud-controller-manager/master/docs/example-manifests/out-of-tree/cloud-controller-manager.yaml
 ```
 
+### Choose a container network plugin
+
+If `--configure-cloud-routes` of CCM is enabled, the `kubernet` plugin is recommended to handle traffic among Pods along with the VPC network.
+You can follow the [document](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#kubenet) to set it up.
+In addition, you need to add some `iptables rules` to accept traffic forwarded between `cbr0` and `eth0`.
+
 ### Verify the installation
 
-1. Wait until all nodes ready.
+1. Wait until all nodes ready. It may take a few minutes.
 2. Deploy [the sample of Service](https://github.com/TencentCloud/tencentcloud-cloud-controller-manager/blob/master/docs/resources/service/README.md).

--- a/docs/resources/service/README.md
+++ b/docs/resources/service/README.md
@@ -1,18 +1,18 @@
 # Service
 
-Tencent CCM could provide a load balancer（CLB）for each Service with `type: LoadBalancer`. **WARNING**:The `spec.sessionAffinity` is not supported.
+Tencent CCM could provide a load balancer（CLB）for each Service with `type: LoadBalancer`. 
+
+**WARNING**:The `spec.sessionAffinity` is not supported.
 
 ## Annotations
 
-You can also change the CLB configuration through the following annotations of Services.
+You can also change the CLB configuration by annotating Service.
  
 [Annotations](https://raw.githubusercontent.com/TencentCloud/tencentcloud-cloud-controller-manager/master/docs/resources/service/annotations.md)
 
 ## Sample
 
-In the sample, we are going to run a nginx and expose it via a LoadBalance type Service. [sample](https://raw.githubusercontent.com/TencentCloud/tencentcloud-cloud-controller-manager/master/docs/resources/service/smaple.yaml)
-
-To deploy Deployment and Service,
+To deploy the sample,
 
 ```shell script
 kubectl apply -f https://raw.githubusercontent.com/TencentCloud/tencentcloud-cloud-controller-manager/master/docs/resources/service/smaple.yaml
@@ -29,3 +29,5 @@ nginx-574b87c764-hgt6d       1/1     Running   0          80s
 NAME                TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)          AGE
 nginx               LoadBalancer   172.18.0.136   106.55.71.219    80:32158/TCP     103s
 ```
+
+You will found that a public IP address is allocated for the Service nginx in the column `EXTERNAL-IP`.

--- a/route-ctl/README_zhCN.md
+++ b/route-ctl/README_zhCN.md
@@ -1,0 +1,68 @@
+# route-ctl
+
+`route-ctl` 是一个用于在腾讯云 vpc 环境创建**容器网络专用路由表**的小工具，典型的应用场景包括
+
+* 在腾讯云从云服务器手工搭建 kubernetes 且集群网络使用路由方案时，可以使用此工具创建 kubernetes 用来建立 pod 网络的子网，使得集群中的 pod 通信能够和腾讯云 vpc 打通
+
+
+## 编译
+
+将此项目 clone 到 GOPATH 下，假设 GOPATH 为 /root/go
+
+```
+mkdir -p /root/go/src/github.com/tencentcloud/
+git clone https://github.com/tencentcloud/tencentcloud-cloud-controller-manager.git /root/go/src/github.com/tencentcloud/tencentcloud-cloud-controller-manager
+cd /root/go/src/github.com/tencentcloud/tencentcloud-cloud-controller-manager/route-ctl
+go build -v
+```
+
+## 使用
+
+**注意**:  routetable 的 cidr 不能与对应 vpc 的 cidr、其他集群的 cidr 以及已经存在的子网的 cidr 存在冲突
+
+使用前需要通过环境变量设置 `QCloudSecretId`、 `QCloudSecretKey` 以及 `QCloudCcsAPIRegion`
+
+```
+export QCloudSecretId=************************************
+export QCloudSecretKey=********************************
+export QCloudCcsAPIRegion=ap-shanghai
+```
+
+### 创建路由表
+```
+./route-ctl route-table create --route-table-cidr-block 10.10.0.0/16 --route-table-name route-table-test --vpc-id vpc-********
+```
+
+当通过 `route-ctl` 创建路由表时， `route-ctl` 会先检查所要创建的路由表的 `cidr` 是否和现存的网络设置冲突，具体的检查包括下面四项：
+
+1. route table 所在 vpc 的 cidr
+2. route table 所在 vpc 的子网路由的 cidr
+3. route table 所在 vpc 的 ccs 集群的集群网络 cidr
+4. route table 所在 vpc 的其它通过 route-ctl 创建的 route table 的 cidr
+
+___Note:___ 当存在 `cidr` 冲突时，`route-ctl` 支持通过 `--ignore-cidr-conflict` 选项忽略冲突进行创建，需要注意的是，通过 route table 创建的具体路由条目在 vpc 内拥有最高的匹配优先级，忽略 `cidr` 冲突进行创建可能会导致现存的网络出现问题，___请谨慎使用___。
+
+### 查看现存的路由表
+```
+./route-ctl route-table list
+```
+
+### 删除指定路由表
+```
+./route-ctl route-table delete --route-table-name route-table-test
+```
+
+### 创建路由
+```
+./route-ctl route create --destination-cidr-block 10.10.1.0/24 --route-table-name route-table-test --gateway-ip 192.168.1.4
+```
+
+### 查看现存的路由
+```
+./route-ctl route list --route-table-name route-table-test
+```
+
+### 删除指定路由
+```
+./route-ctl route delete --destination-cidr-block 10.10.1.0/24 --route-table-name route-table-test --gateway-ip 192.168.1.4
+```


### PR DESCRIPTION
1. Fixed the description of route tables.
2. Added contents about container network plugins.
3. Document of `route-ctl`.